### PR TITLE
Ребаланс аплинка

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -7,7 +7,7 @@
   description: uplink-pistol-viper-desc
   productEntity: WeaponPistolViper
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkWeapons
 
@@ -50,7 +50,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_sword.rsi, state: icon }
   productEntity: EnergySword
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   categories:
   - UplinkWeapons
 
@@ -102,6 +102,22 @@
           - NukeOpsUplink
 
 - type: listing
+  id: UplinkEswordDouble
+  name: uplink-esword-double-name
+  description: uplink-esword-double-desc
+  icon: { sprite: /Textures/Objects/Weapons/Melee/e_sword_double.rsi, state: icon }
+  productEntity: EnergySwordDouble
+  cost:
+    Telecrystal: 35 #(Originally 16)
+  categories:
+  - UplinkWeapons
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
+- type: listing
   id: UplinkDisposableTurret
   name: uplink-disposable-turret-name
   description: uplink-disposable-turret-desc
@@ -144,7 +160,7 @@
   description: uplink-mini-bomb-desc
   productEntity: SyndieMiniBomb
   cost:
-    Telecrystal: 6
+    Telecrystal: 5
   categories:
     - UplinkExplosives
 
@@ -164,7 +180,7 @@
   description: uplink-whitehole-grenade-desc
   productEntity: WhiteholeGrenade
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
     - UplinkExplosives
 
@@ -199,7 +215,7 @@
   description: uplink-grenadier-rig-desc
   productEntity: ClothingBeltMilitaryWebbingGrenadeFilled
   cost:
-    Telecrystal: 12
+    Telecrystal: 10
   categories:
   - UplinkExplosives
   conditions:
@@ -235,7 +251,7 @@
   icon: { sprite: /Textures/Objects/Misc/bureaucracy.rsi, state: pen }
   productEntity: PenExplodingBox
   cost:
-    Telecrystal: 5
+    Telecrystal: 2
   categories:
   - UplinkExplosives
 
@@ -245,10 +261,10 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 10
   categories:
     - UplinkExplosives
-  restockTime: 30
+  restockTime: 20
 
 # Ammo
 
@@ -271,7 +287,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag.rsi, state: red-icon }
   productEntity: MagazinePistolSubMachineGun
   cost:
-    Telecrystal: 3
+    Telecrystal: 2
   categories:
   - UplinkAmmo
   conditions:
@@ -335,7 +351,7 @@
   icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
   productEntity: BoxHoloparasite
   cost:
-    Telecrystal: 14
+    Telecrystal: 10
   categories:
   - UplinkUtility
   conditions:
@@ -423,7 +439,7 @@
   productEntity: ReinforcementRadioSyndicateMonkey
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 8
+    Telecrystal: 6
   categories:
   - UplinkUtility
 
@@ -526,7 +542,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: freedom }
   productEntity: FreedomImplanter
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
     - UplinkImplants
 
@@ -537,7 +553,7 @@
   icon: { sprite: /Textures/Mobs/Species/Human/parts.rsi, state: full }
   productEntity: DnaScramblerImplanter
   cost:
-    Telecrystal: 10
+    Telecrystal: 8
   categories:
     - UplinkImplants
 
@@ -559,7 +575,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
   productEntity: MicroBombImplanter
   cost:
-    Telecrystal: 2
+    Telecrystal: 3
   categories:
   - UplinkImplants
   conditions:
@@ -599,7 +615,7 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 2
+    Telecrystal: 4
   categories:
   - UplinkImplants
 
@@ -656,7 +672,7 @@
   description: uplink-ammo-bundle-desc
   productEntity: ClothingBackpackDuffelSyndicateAmmoFilled
   cost:
-    Telecrystal: 15
+    Telecrystal: 16
   categories:
   - UplinkBundles
   conditions:
@@ -695,7 +711,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
   productEntity: BriefcaseSyndieSniperBundleFilled
   cost:
-    Telecrystal: 12
+    Telecrystal: 14
   categories:
   - UplinkBundles
 
@@ -728,7 +744,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Launchers/china_lake.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   cost:
-    Telecrystal: 25
+    Telecrystal: 30
   categories:
   - UplinkBundles
 
@@ -750,7 +766,7 @@
   icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
   productEntity: ClothingBackpackDuffelZombieBundle
   cost:
-    Telecrystal: 40
+    Telecrystal: 42
   categories:
   - UplinkBundles
   conditions:
@@ -932,7 +948,7 @@
   description: uplink-revolver-cap-gun-fake-desc
   productEntity: RevolverCapGunFake
   cost:
-    Telecrystal: 9
+    Telecrystal: 10
   categories:
   - UplinkJob
   conditions:
@@ -977,7 +993,7 @@
   description: uplink-hot-potato-desc
   productEntity: HotPotato
   cost:
-    Telecrystal: 4
+    Telecrystal: 5
   categories:
   - UplinkJob
   conditions:
@@ -994,7 +1010,7 @@
   description: uplink-chimp-upgrade-kit-desc
   productEntity: WeaponPistolCHIMPUpgradeKit
   cost:
-    Telecrystal: 4
+    Telecrystal: 6
   categories:
   - UplinkJob
   conditions:
@@ -1069,7 +1085,7 @@
   description: uplink-clothing-thieving-gloves-desc
   productEntity: ThievingGloves
   cost:
-    Telecrystal: 4
+    Telecrystal: 5
   categories:
   - UplinkArmor
 
@@ -1121,7 +1137,7 @@
   description: uplink-clothing-outer-hardsuit-juggernaut-desc
   productEntity: ClothingOuterHardsuitJuggernaut
   cost:
-    Telecrystal: 12
+    Telecrystal: 16
   categories:
   - UplinkArmor
 
@@ -1217,6 +1233,10 @@
     Telecrystal: 5
   categories:
   - UplinkMisc
+  conditions:
+  - !type:BuyerJobCondition # We can't use BuyerDepartmentCondition here since Zookeeper and Chef can also get this
+    whitelist:
+    - Chemist
 
 - type: listing
   id: UplinkCombatMedkit
@@ -1302,7 +1322,7 @@
   description: uplink-syndicate-stamp-desc
   productEntity: RubberStampSyndicate
   cost:
-    Telecrystal: 2
+    Telecrystal: 1
   categories:
   - UplinkPointless
 


### PR DESCRIPTION
Изменения стоимости и доступности предметов
- Кобра (3->2) ** Почти самый ДПС в игре среди пистолетов, стоимость явно завышена
- Энергетический меч (8->6) ** Энергокинжал за 2 тк выглядит сочнее, меч не берут...
- Двойной Энергетический меч (Теперь доступен ядерным оперативникам по цене 35тк [для агентов 20тк]) ** двойной меч на солонюке, но без оружия? Звучит интересно, в случае чего отдельно убрать...
- Мини-бомба синдиката (6->5) ** Не взрывает на свои деньги! Я бы сделал 4 тк вообще
- Граната белой дыры (3->2) ** Вообще бесполезна...
- РПС гренадёра (12->10) ** Не имеет в себе на 12 тк...
- Взрыворучка (5->2) ** ПОЧЕМУ ОНА СТОИЛА ТАК ДОРОГО!??
- Бомба синдиката (11->10)
- Магазин с20р (3->2) **Цена завышена ни за что, даже патроны к христову дешевле
- Голопаразит (14->10)
- Радио обезьянего подкрепления (8->6) ** У обезьяны очень мало возможностей, она не может даже носить несколько предметов
- Имплант свободы (5->4) ** Им никто не пользуется, создаём скидон!
- ДНК миксер (10->8) ** Дорогой, и никто не пользуется, легко палится
- Имплант микробомбы (2->3) ** Он хорош, и дешёв, платите больше!
- Имплант разжижения (2->4) ** Слишком дешёвый за возможность неоставлять улик! (так его ещё и жертве колоть можно)
- Рюкзак с патронам (15->16) ** Слишком харош
- Набор снайпера (12->14) ** Христов с патронами, без коментариев
- Набор гренадёра (25->30) ** Чёртов чайналейк! Имба
- Набор зомбифицирования (40->42) ** Солонюк не должен устраивать зомби апокалипсис, и скинувшиеся агенты тоже
- Фейковый кэпган (9->10)
- Горячая картошка (4->5)
- Апгрейд МАРТЫХ (4->6)
- Перчатки вора (4->5)
- Скафандр джагернаут (12->16)
- Ноктюрин (теперь только для химиков)
- Печать синдиката (2->1)