### PR TITLE
Добавление бинтов в кастомизацию слаймов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
@@ -2,7 +2,7 @@
   id: GauzeLefteyePatch
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: GauzeLefteyeTape
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -30,7 +30,7 @@
   id: GauzeRighteyePatch
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -44,7 +44,7 @@
   id: GauzeRighteyeTape
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: GauzeBlindfold
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -72,7 +72,7 @@
   id: GauzeShoulder
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -86,7 +86,7 @@
   id: GauzeStomach
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -100,7 +100,7 @@
   id: GauzeUpperArmRight
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -114,7 +114,7 @@
   id: GauzeLowerArmRight
   bodyPart: RArm, RHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -128,7 +128,7 @@
   id: GauzeLeftArm
   bodyPart: LArm, LHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -142,7 +142,7 @@
   id: GauzeLowerLegLeft
   bodyPart: LFoot
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -156,7 +156,7 @@
   id: GauzeUpperLegLeft
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -170,7 +170,7 @@
   id: GauzeUpperLegRight
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -184,7 +184,7 @@
   id: GauzeLowerLegRight
   bodyPart: RFoot
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -198,7 +198,7 @@
   id: GauzeBoxerWrapRight
   bodyPart: RHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:
@@ -212,7 +212,7 @@
   id: GauzeBoxerWrapLeft
   bodyPart: LHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
   coloring:
     default:
       type:


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Слаймы теперь могут ходить с бинтами из кастомизации

## Цель / Баланс 
Почему-то бинты убрали из кастомизации слаймов, что нелогично, ибо слаймов мы можем лечить наборами от ушибов и бинтами

## Медиа
![изображение](https://github.com/ss14-ganimed/ENT14-Master/assets/139872389/ac53136a-30bc-4b6c-8722-d54b0f57734a)

- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует. 

## Проверки
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR
[X] пометит галочкой -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.

:cl: Gorox
- fix: Добавлены бинты в кастомизацию слаймов
